### PR TITLE
Scope re-init to infinite scrolling js

### DIFF
--- a/app/assets/javascripts/modules/infinite-scrolling.coffee
+++ b/app/assets/javascripts/modules/infinite-scrolling.coffee
@@ -21,7 +21,7 @@ class @InfiniteScrolling
       if url
         @disable()
         $.getScript url, ->
-          new Init()
+          new InfiniteScrolling()
           return
     return
 


### PR DESCRIPTION
It might be safer to only re-init the infinite scrolling javascript in order to avoid unwanted resets of other javascript features in the page.

P.S. I'm using this implementation in a current project and it works great! Thank you!